### PR TITLE
Fix -> #133 - npm EACCES error

### DIFF
--- a/src/Gewohnheitstier/Dockerfile.dev
+++ b/src/Gewohnheitstier/Dockerfile.dev
@@ -1,12 +1,16 @@
+# syntax=docker/dockerfile:1.7
 FROM node:20-bullseye
+
+RUN apt-get update && apt-get install -y --no-install-recommends tini && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY package*.json ./
-RUN apt-get update && apt-get install -y --no-install-recommends tini \
-    && npm install && rm -rf /var/lib/apt/lists/*
+RUN npm install
 
 COPY . .
+
 RUN useradd -m appuser && chown -R appuser:appuser /app
 USER appuser
-
-CMD ["npm", "run", "dev"]
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["npm","run","dev"]

--- a/src/Gewohnheitstier/docker-compose.yml
+++ b/src/Gewohnheitstier/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   server:
     build:
@@ -16,7 +14,7 @@ services:
       - HOST=0.0.0.0
     ports:
       - "3001:3001"
-      # NUR subfolders mounten, nicht /app -> hindert ueberschreiben der file permissions 
+    # NUR subfolders mounten, nicht /app -> hindert ueberschreiben der file permissions 
     volumes:
       - ./project/server/src:/app/src
       - ./project/server/package.json:/app/package.json
@@ -35,17 +33,17 @@ services:
       - CHOKIDAR_USEPOLLING=true
       - PORT=5173
       - HOST=0.0.0.0
+    # beide gängigen Dev-Ports freigeben; der ungenutzte bleibt halt leer
     ports:
-      - "5173:5173" # Vite
-      - "3000:3000" # CRA
-      # NUR subfolders mounten, nicht /app -> hindert ueberschreiben der file permissions 
+      - "5173:5173"   # Vite
+      - "3000:3000"   # CRA
+    # NUR subfolders mounten, nicht /app -> hindert ueberschreiben der file permissions 
     volumes:
       - ./project/client/src:/app/src
       - ./project/client/package.json:/app/package.json
       - node_modules_client:/app/node_modules
     depends_on:
       - server
-
 volumes:
   node_modules_server:
   node_modules_client:


### PR DESCRIPTION
Ich musste ein wenig rumprobieren bis ich es zum Laufen bekommen habe. Die Unterordner einzeln zu mounten war bei mir der einfachste weg, um zu verhindern dass die file permissions überschrieben werden.

Funktioniert das bei euch auch so weit oder kommen dadurch ungewollte Fehler zustande / müssen wir /app als gesamtes mounten? Dann müsste ich nochmal was anderes raussuchen. Ich wollte es erstmal die app als root auszuführen.