### PR TITLE
backend/#158/SwaggerUI/Paul

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -3,6 +3,8 @@ const express = require('express');
 const cors = require('cors'); // CORS-Middleware importieren um Frontend mit Backend kommunizieren zu lassen
 const habitsRouter = require('./src/routes/habits');
 const authRouter = require('./src/routes/auth');
+const swaggerUi = require('swagger-ui-express');
+const { specs } = require('./src/swagger');
 
 const app = express();
 
@@ -26,6 +28,7 @@ app.get('/', (_req, res) => {
 
 app.use('/api/auth', authRouter); // Auth-Routen
 app.use('/api/habits', habitsRouter); // Habits-Routen
+app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(specs)); // Swagger UI
 
 
 

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -11,12 +11,64 @@
       "dependencies": {
         "@prisma/client": "^6.19.0",
         "cors": "^2.8.5",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "nodemon": "^3.1.10",
         "prisma": "^6.19.0"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
     },
     "node_modules/@prisma/client": {
       "version": "6.19.0",
@@ -96,11 +148,24 @@
         "@prisma/debug": "6.19.0"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "devOptional": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -127,11 +192,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -168,7 +238,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -277,6 +346,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -310,11 +385,19 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/confbox": {
       "version": "0.2.2",
@@ -423,6 +506,18 @@
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "devOptional": true
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -511,6 +606,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -633,6 +737,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -705,6 +815,27 @@
       },
       "bin": {
         "giget": "dist/cli.mjs"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -801,6 +932,17 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -870,6 +1012,38 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -920,7 +1094,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1048,12 +1221,28 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1408,6 +1597,62 @@
         "node": ">=4"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -1473,6 +1718,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1485,6 +1739,45 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     }
   }
 }

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "@prisma/client": "^6.19.0",
     "cors": "^2.8.5",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10",

--- a/src/backend/src/routes/auth.js
+++ b/src/backend/src/routes/auth.js
@@ -8,6 +8,46 @@ const {
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/auth/login:
+ *   post:
+ *     summary: Nutzer anmelden
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email, password]
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Login erfolgreich
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthSession'
+ *       400:
+ *         description: Fehlende Felder
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Falsche Zugangsdaten
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+
 router.post('/login', async (req, res) => {
   const { email, password } = req.body || {};
   if (!email || !password) {
@@ -28,6 +68,45 @@ router.post('/login', async (req, res) => {
     res.status(status).json({ error: 'Login failed', detail: err.message });
   }
 });
+
+/**
+ * @swagger
+ * /api/auth/register:
+ *   post:
+ *     summary: Nutzer registrieren
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email, password]
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *               password:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Registrierung erfolgreich
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   $ref: '#/components/schemas/AuthUser'
+ *                 session:
+ *                   oneOf:
+ *                     - $ref: '#/components/schemas/AuthSession'
+ *                     - type: 'null'
+ *       400:
+ *         description: Fehlende Felder
+ *       500:
+ *         description: Serverfehler
+ */
 
 router.post('/register', async (req, res) => {
   const { email, password } = req.body || {};
@@ -53,6 +132,37 @@ router.post('/register', async (req, res) => {
     res.status(status).json({ error: 'Registration failed', detail: err.message });
   }
 });
+/**
+ * @swagger
+ * /api/auth/session:
+ *   post:
+ *     summary: Token prüfen und User liefern
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [accessToken]
+ *             properties:
+ *               accessToken:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Token gültig
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   $ref: '#/components/schemas/AuthUser'
+ *       400:
+ *         description: Fehlende Felder
+ *       401:
+ *         description: Ungültiges Token
+ */
 
 router.post('/session', async (req, res) => {
   const { accessToken } = req.body || {};
@@ -68,7 +178,37 @@ router.post('/session', async (req, res) => {
     res.status(status).json({ error: 'Session lookup failed', detail: err.message });
   }
 });
-
+/**
+ * @swagger
+ * /api/auth/logout:
+ *   post:
+ *     summary: Token abmelden
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [accessToken]
+ *             properties:
+ *               accessToken:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Logout erfolgreich
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       400:
+ *         description: Fehlende Felder
+ *       401:
+ *         description: Ungültiges Token
+ */
 router.post('/logout', async (req, res) => {
   const { accessToken } = req.body || {};
   if (!accessToken) {

--- a/src/backend/src/routes/habits.js
+++ b/src/backend/src/routes/habits.js
@@ -25,6 +25,31 @@ function normalizeDateArray(value) {
 
 router.use(authenticate);
 
+/**
+ * @swagger
+ * /api/habits:
+ *   get:
+ *     summary: Liste aller Habits des angemeldeten Nutzers
+ *     tags: [Habits]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Erfolgreich
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Habit'
+ *       401:
+ *         description: Kein oder ungültiges Token
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+
 router.get('/', async (req, res) => {
   try {
     const userId = req.auth.user.id;
@@ -38,7 +63,38 @@ router.get('/', async (req, res) => {
     res.status(500).json({ error: 'Failed to fetch habits' });
   }
 });
-
+/**
+ * @swagger
+ * /api/habits:
+ *   post:
+ *     summary: Neues Habit anlegen
+ *     tags: [Habits]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name]
+ *             properties:
+ *               name:
+ *                 type: string
+ *               desc:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Habit angelegt
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Habit'
+ *       400:
+ *         description: Name fehlt oder ungültig
+ *       401:
+ *         description: Kein oder ungültiges Token
+ */
 router.post('/', async (req, res) => {
   const { name, desc } = req.body || {};
 
@@ -67,6 +123,31 @@ router.post('/', async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /api/habits/{id}:
+ *   delete:
+ *     summary: Habit löschen
+ *     tags: [Habits]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: ID des Habits
+ *     responses:
+ *       204:
+ *         description: Erfolgreich gelöscht
+ *       400:
+ *         description: Ungültige ID
+ *       404:
+ *         description: Habit nicht gefunden
+ *       401:
+ *         description: Kein oder ungültiges Token
+ */
 router.delete('/:id', async (req, res) => {
   const idParam = req.params.id;
   let habitId;
@@ -93,7 +174,35 @@ router.delete('/:id', async (req, res) => {
     res.status(500).json({ error: 'Failed to delete habit' });
   }
 });
-
+/**
+ * @swagger
+ * /api/habits/{id}/toggle:
+ *   post:
+ *     summary: Habit für heute erledigt / rückgängig schalten
+ *     tags: [Habits]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: ID des Habits
+ *     responses:
+ *       200:
+ *         description: Aktualisiertes Habit
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Habit'
+ *       400:
+ *         description: Ungültige ID
+ *       404:
+ *         description: Habit nicht gefunden
+ *       401:
+ *         description: Kein oder ungültiges Token
+ */
 router.post('/:id/toggle', async (req, res) => {
   const idParam = req.params.id;
   let habitId;

--- a/src/backend/src/swagger.js
+++ b/src/backend/src/swagger.js
@@ -1,0 +1,73 @@
+const swaggerJSDoc = require('swagger-jsdoc');
+
+const port = process.env.PORT || 5000;
+const serverUrl = process.env.SWAGGER_SERVER_URL || `http://localhost:${port}`;
+
+const options = {
+  definition: {
+    openapi: '3.0.3',
+    info: {
+      title: 'Gewohnheitstier API',
+      version: '1.0.0',
+      description: 'REST-API für Authentifizierung und Gewohnheiten',
+    },
+    servers: [{ url: serverUrl, description: 'Lokale Entwicklung' }],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+      schemas: {
+        Habit: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: '123' },
+            habit_name: { type: 'string', example: 'Joggen' },
+            description: { type: 'string', example: '30 Minuten laufen' },
+            start_date: { type: 'string', format: 'date', example: '2025-01-01' },
+            streak: { type: 'integer', example: 5 },
+            last_checked: { type: 'string', format: 'date-time', nullable: true },
+            prev_last_checked: {
+              type: 'array',
+              items: { type: 'string', format: 'date-time' },
+            },
+            user_id: { type: 'string', example: 'uuid' },
+          },
+          required: ['id', 'habit_name', 'user_id'],
+        },
+        AuthUser: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'uuid' },
+            email: { type: 'string', format: 'email' },
+          },
+        },
+        AuthSession: {
+          type: 'object',
+          properties: {
+            accessToken: { type: 'string' },
+            refreshToken: { type: 'string' },
+            expiresIn: { type: 'integer' },
+            tokenType: { type: 'string' },
+            user: { $ref: '#/components/schemas/AuthUser' },
+          },
+        },
+        ErrorResponse: {
+          type: 'object',
+          properties: {
+            error: { type: 'string' },
+            detail: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+  apis: ['./src/routes/*.js'],
+};
+
+const specs = swaggerJSDoc(options);
+
+module.exports = { specs };

--- a/src/dev-start.sh
+++ b/src/dev-start.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Optional: ins Projektverzeichnis wechseln (Ordner anpassen/entfernen)
+# cd "$(dirname "$0")/.."
+
+# Supabase lokal starten
+supabase start
+
+# Docker Compose (dev) hochfahren + build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build

--- a/src/docu/swaggerUI.adoc
+++ b/src/docu/swaggerUI.adoc
@@ -1,0 +1,185 @@
+= Swagger UI Setup (Backend)
+:toc:
+:toclevels: 3
+
+Ziel: Eine klickbare API-Dokumentation unter `/api/docs` bereitstellen, basierend auf unseren bestehenden Express-Routen (`/api/auth/*`, `/api/habits/*`). Diese Anleitung führt Schritt für Schritt durch Installation, Konfiguration und Pflege.
+
+== 1) Pakete installieren
+Im Backend-Verzeichnis:
+----
+cd src/backend
+npm install swagger-ui-express swagger-jsdoc
+----
+
+== 2) OpenAPI-Definition vorbereiten
+Lege z. B. `src/swagger.js` im Backend an. Beispielgrundgerüst (kann angepasst/erweitert werden):
+----
+// src/swagger.js
+const swaggerJSDoc = require('swagger-jsdoc');
+
+const options = {
+  definition: {
+    openapi: '3.0.3',
+    info: {
+      title: 'Habit Tracker API',
+      version: '1.0.0',
+      description: 'REST-API für Authentifizierung und Gewohnheiten',
+    },
+    servers: [
+      { url: 'http://localhost:3001', description: 'Lokale Entwicklung' },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+      schemas: {
+        Habit: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: '123' },
+            habit_name: { type: 'string', example: 'Joggen' },
+            description: { type: 'string', example: '30 Minuten laufen' },
+            start_date: { type: 'string', format: 'date', example: '2025-01-01' },
+            streak: { type: 'integer', example: 5 },
+            last_checked: { type: 'string', format: 'date-time', nullable: true },
+            prev_last_checked: {
+              type: 'array',
+              items: { type: 'string', format: 'date-time' },
+            },
+            user_id: { type: 'string', example: 'uuid' },
+          },
+          required: ['id', 'habit_name', 'user_id'],
+        },
+        AuthUser: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'uuid' },
+            email: { type: 'string', format: 'email' },
+          },
+        },
+        AuthSession: {
+          type: 'object',
+          properties: {
+            accessToken: { type: 'string' },
+            refreshToken: { type: 'string' },
+            expiresIn: { type: 'integer' },
+            tokenType: { type: 'string' },
+            user: { $ref: '#/components/schemas/AuthUser' },
+          },
+        },
+        ErrorResponse: {
+          type: 'object',
+          properties: { error: { type: 'string' }, detail: { type: 'string' } },
+        },
+      },
+    },
+  },
+  apis: ['./src/routes/*.js'], // Pfade zu den Dateien mit Swagger-JSDoc-Kommentaren
+};
+
+const specs = swaggerJSDoc(options);
+module.exports = { specs };
+----
+
+== 3) Routen mit JSDoc-kommentieren
+In den Route-Dateien (`src/routes/auth.js`, `src/routes/habits.js`) oberhalb der Handler JSDoc mit OpenAPI-Annotations ergänzen. Beispiel für `auth.js` (Login):
+----
+/**
+ * @swagger
+ * /api/auth/login:
+ *   post:
+ *     summary: Nutzer anmelden
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email, password]
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Login erfolgreich
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthSession'
+ *       400:
+ *         description: Fehlende Felder
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Falsche Zugangsdaten
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+----
+
+Beispiel für `habits.js` (GET /api/habits):
+----
+/**
+ * @swagger
+ * /api/habits:
+ *   get:
+ *     summary: Liste aller Gewohnheiten des angemeldeten Nutzers
+ *     tags: [Habits]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Erfolgreich
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Habit'
+ *       401:
+ *         description: Kein/ungültiges Token
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+----
+
+Weitere Endpunkte analog dokumentieren:
+* POST `/api/habits` (Body: name, desc?)
+* DELETE `/api/habits/{id}`
+* POST `/api/habits/{id}/toggle`
+* POST `/api/auth/register`
+* POST `/api/auth/session`
+* POST `/api/auth/logout`
+
+== 4) Swagger UI einbinden
+In `index.js` (Backend) ergänzen:
+----
+const swaggerUi = require('swagger-ui-express');
+const { specs } = require('./src/swagger'); // Pfad anpassen, falls nötig
+
+app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(specs));
+----
+
+== 5) Starten und prüfen
+* Backend starten (z. B. `npm run dev` im Backend oder `docker compose up`).
+* Im Browser `http://localhost:3001/api/docs` (oder dein Port) öffnen.
+* Es sollte die Swagger UI erscheinen, in der alle beschriebenen Endpunkte klickbar sind.
+
+== 6) Pflegehinweise
+* Bei neuen oder geänderten Routen JSDoc-Kommentare anpassen, damit die UI aktuell bleibt.
+* Schemas (`components.schemas`) erweitern, wenn neue Felder dazukommen.
+* Sicherheit: Alle geschützten Endpunkte mit `security: - bearerAuth: []` markieren.


### PR DESCRIPTION
## Beschreibung / Motivation

Die API soll klar dokumentiert und schnell testbar sein.  
Swagger UI stellt hierfür eine zentrale Dokumentation mit manuellen Testmöglichkeiten bereit.

## Änderungen

- Swagger-Setup im Backend ergänzt (`swagger-jsdoc`, `swagger-ui-express`), neuer Endpoint unter `/api/docs`
- OpenAPI-Metadaten (Titel, Version, Server-URL, JWT-Security-Scheme) in `src/backend/src/swagger.js` definiert
- Zentrale Schemas für Auth (`AuthUser`, `AuthSession`, `ErrorResponse`) und Habits (`Habit`) ergänzt
- Auth- und Habit-Routen mit Swagger-JSDoc-Kommentaren annotiert, sodass sie automatisch in der UI erscheinen
- Dokumentation unter  
  [`Swagger UI – Backend-Dokumentation`](https://github.com/1tristan0/SE-HabitTracker-3.B/blob/backend/%23158/SwaggerUI/Paul/src/docu/swaggerUI.adoc)  
  um Setup- und Nutzungshinweise erweitert
- `package-lock.json` aktualisiert, damit `npm ci` mit den neuen Swagger-Abhängigkeiten konsistent durchläuft

## Wie wurde getestet?

- `./dev-start.sh`
- `http://localhost:3001/api/docs/`

- **Swagger UI lädt korrekt**
- **Alle dokumentierten Routen inkl. Schemas werden angezeigt**
- Stichprobenweise Ausführung von Auth- und Habit-Endpunkten in der UI (mit gültigem Token)
  - Responses entsprechen der Dokumentation

## Hinweise für Reviewer

- Die Server-URL in Swagger kann über die Umgebungsvariable `SWAGGER_SERVER_URL` überschrieben werden, andernfalls wird `http://localhost:<PORT>` verwendet
- Bitte die definierten Schema-Felder (z. B. `Habit.prev_last_checked`, `streak`) kurz gegen die fachlichen Erwartungen prüfen
- Bei neuen oder geänderten Routen genügt das Ergänzen eines JSDoc-Blocks – sie erscheinen automatisch unter `/api/docs`